### PR TITLE
es-module-lexer should be a dependency, not dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "url": "https://github.com/jy0529/vite-plugin-dynamic-publicpath/issues"
   },
   "homepage": "https://github.com/jy0529/vite-plugin-dynamic-publicpath#readme",
+  "dependencies": {
+    "es-module-lexer": "^0.6.0"
+  },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "es-module-lexer": "^0.6.0",
     "vite": "^2.4.0"
   }
 }


### PR DESCRIPTION
Trying to use this module from an npm install results in:

```
Error: Cannot find module 'es-module-lexer'
```
As a temporary workaround, installing that fixes it but really should be defined in "dependencies" rather than "devDependencies"